### PR TITLE
Provide SubscribeWrapper in Message package

### DIFF
--- a/internal/mqtt/publisher.go
+++ b/internal/mqtt/publisher.go
@@ -64,10 +64,8 @@ func (p *mqttPublisher) Publish(msg message.PublishWrapper) error {
 	if err != nil {
 		return err
 	}
-	b, err := json.Marshal(msg)
-	if err != nil {
-		return err
-	}
+
+	b, _ := json.Marshal(newMqttWrapper(msg))
 	// publish to all topics
 	for _, topic := range p.endpoint.Topics {
 		p.logger.Write(logging.DebugLevel, fmt.Sprintf("attempting publish, topic %s %s", topic, string(b)))
@@ -90,4 +88,19 @@ func (p *mqttPublisher) reconnect() error {
 		}
 	}
 	return nil
+}
+
+type mqttWrapper struct {
+	Action      message.SdkAction `json:"action,omitempty"`
+	MessageType string            `json:"messageType,omitempty"`
+	Content     []byte            `json:"content,omitempty"`
+}
+
+func newMqttWrapper(msg message.PublishWrapper) mqttWrapper {
+	b, _ := json.Marshal(msg.Content)
+	return mqttWrapper{
+		Action:      msg.Action,
+		MessageType: msg.MessageType,
+		Content:     b,
+	}
 }

--- a/pkg/contracts/annotation.go
+++ b/pkg/contracts/annotation.go
@@ -26,7 +26,7 @@ type Annotation struct {
 	Key       string         `json:"key,omitempty"`       // Key is the hash value of the data being annotated
 	Hash      HashType       `json:"hash,omitempty"`      // Hash identifies which algorithm was used to construct the hash
 	Host      string         `json:"host,omitempty"`      // Host is the hostname of the node making the annotation
-	Kind      AnnotationType `json:"type,omitempty"`      // Kind indicates what kind of annotation this is
+	Kind      AnnotationType `json:"kind,omitempty"`      // Kind indicates what kind of annotation this is
 	Signature string         `json:"signature,omitempty"` // Signature contains the signature of the party making the annotation
 	Satisfied bool           `json:"satisfied"`           // Satisfied indicates whether the criteria defining the annotation were fulfilled
 	Timestamp time.Time      `json:"timestamp,omitempty"` // Timestamp indicates when the annotation was created
@@ -72,7 +72,7 @@ func (a *Annotation) UnmarshalJSON(data []byte) (err error) {
 	}
 
 	if !x.Kind.Validate() {
-		return fmt.Errorf("invalid AnnotationType value provided %s", x.Hash)
+		return fmt.Errorf("invalid AnnotationType value provided %s", x.Kind)
 	}
 
 	a.Id = x.Id

--- a/pkg/message/types.go
+++ b/pkg/message/types.go
@@ -33,3 +33,9 @@ type PublishWrapper struct {
 	MessageType string      `json:"messageType,omitempty"`
 	Content     interface{} `json:"content,omitempty"`
 }
+
+type SubscribeWrapper struct {
+	Action      SdkAction `json:"action,omitempty"`
+	MessageType string    `json:"messageType,omitempty"`
+	Content     []byte    `json:"content,omitempty"`
+}


### PR DESCRIPTION
Fix #3

* Implemented "Content" property handling as described in issue for MQTT
  publisher only.
* Corrected error message in Annotation.Unmarshal()
* Discovered that Annotation.Kind would not unmarshal correctly with JSON key
  of "type". The value was always blank and validation during unmarshal would
  fail. Probably b/c "type" is somehow a reserved word.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>