### PR TITLE
Implemented TLS Annotator

### DIFF
--- a/internal/annotators/tls.go
+++ b/internal/annotators/tls.go
@@ -1,0 +1,58 @@
+package annotators
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"github.com/project-alvarium/alvarium-sdk-go/pkg/config"
+	"github.com/project-alvarium/alvarium-sdk-go/pkg/contracts"
+	"github.com/project-alvarium/alvarium-sdk-go/pkg/interfaces"
+	"os"
+)
+
+type TlsAnnotator struct {
+	hash contracts.HashType
+	kind contracts.AnnotationType
+	sign config.SignatureInfo
+}
+
+func NewTlsAnnotator(cfg config.SdkInfo) interfaces.Annotator {
+	a := TlsAnnotator{}
+	a.hash = cfg.Hash.Type
+	a.kind = contracts.AnnotationTLS
+	a.sign = cfg.Signature
+	return &a
+}
+
+func (a *TlsAnnotator) Do(ctx context.Context, data []byte) (contracts.Annotation, error) {
+	key := deriveHash(a.hash, data)
+	hostname, _ := os.Hostname()
+	isSatisfied := false
+
+	// Currently this annotator should only be used in the context of HTTP. TLS is also applicable to pub/sub but
+	// a different approach may be required in that scenario to annotate based on the connection rather than per
+	// message. More thought required.
+	//
+	// The methodology below is also very suitable to HTTP requests given that the tls.ConnectionState is readily
+	// available off the incoming request whereas pub/sub connection providers may only expose the tls.Config (see
+	// https://pkg.go.dev/crypto/tls#Config) requiring a function implementation for
+	// VerifyConnection func(ConnectionState) error
+	val := ctx.Value(contracts.AnnotationTLS)
+	if val != nil {
+		tls, ok := val.(*tls.ConnectionState)
+		if !ok {
+			return contracts.Annotation{}, errors.New(fmt.Sprintf("unexpected type %T", tls))
+		}
+		if tls != nil {
+			isSatisfied = tls.HandshakeComplete
+		}
+	}
+	annotation := contracts.NewAnnotation(key, a.hash, hostname, a.kind, isSatisfied)
+	sig, err := signAnnotation(a.sign.PrivateKey, annotation)
+	if err != nil {
+		return contracts.Annotation{}, err
+	}
+	annotation.Signature = string(sig)
+	return annotation, nil
+}

--- a/internal/annotators/tls_test.go
+++ b/internal/annotators/tls_test.go
@@ -1,0 +1,142 @@
+package annotators
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/project-alvarium/alvarium-sdk-go/pkg/config"
+	"github.com/project-alvarium/alvarium-sdk-go/pkg/contracts"
+	"github.com/project-alvarium/alvarium-sdk-go/test"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTlsAnnotator_Base(t *testing.T) {
+	b, err := ioutil.ReadFile("../../test/res/config.json")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	var cfg config.SdkInfo
+	err = json.Unmarshal(b, &cfg)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	badHashType := cfg
+	badHashType.Hash.Type = "invalid"
+
+	badKeyType := cfg
+	badKeyType.Signature.PrivateKey.Type = "invalid"
+
+	keyNotFound := cfg
+	keyNotFound.Signature.PrivateKey.Path = "/dev/null/private.key"
+
+	rndString := test.FactoryRandomFixedLengthString(1024, test.AlphanumericCharset)
+	tests := []struct {
+		name        string
+		data        string
+		cfg         config.SdkInfo
+		expectError bool
+	}{
+		{"tls annotation OK", rndString, cfg, false},
+		{"tls bad hash type", rndString, badHashType, false}, // returns "none" hash type
+		{"tls bad key type", rndString, badKeyType, true},
+		{"tls key not found", rndString, keyNotFound, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tls := NewTlsAnnotator(tt.cfg)
+			anno, err := tls.Do(context.Background(), []byte(tt.data))
+			test.CheckError(err, tt.expectError, tt.name, t)
+			if err == nil {
+				result, err := verifySignature(tt.cfg.Signature.PublicKey, anno)
+				if err != nil {
+					t.Error(err.Error())
+				} else if !result {
+					t.Error("signature not verified")
+				}
+			}
+		})
+	}
+}
+
+func TestTlsAnnotator_ServeTLS(t *testing.T) {
+	b, err := ioutil.ReadFile("../../test/res/config.json")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	var cfg config.SdkInfo
+	err = json.Unmarshal(b, &cfg)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	tls := NewTlsAnnotator(cfg)
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), contracts.AnnotationTLS, r.TLS)
+		anno, err := tls.Do(ctx, []byte(test.FactoryRandomFixedLengthString(1024, test.AlphanumericCharset)))
+		if err != nil {
+			t.Error(err)
+		}
+		b, _ := json.Marshal(anno)
+		w.Write(b)
+	}))
+	defer ts.Close()
+
+	client := ts.Client()
+	result, err := client.Get(ts.URL)
+	if err != nil {
+		t.Error(err)
+	} else {
+		defer result.Body.Close()
+		var a contracts.Annotation
+		body, _ := io.ReadAll(result.Body)
+		json.Unmarshal(body, &a)
+		if !a.IsSatisfied {
+			t.Error("annotation.IsSatisfied should be true")
+		}
+	}
+}
+
+func TestTlsAnnotator_Serve(t *testing.T) {
+	b, err := ioutil.ReadFile("../../test/res/config.json")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	var cfg config.SdkInfo
+	err = json.Unmarshal(b, &cfg)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	tls := NewTlsAnnotator(cfg)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), contracts.AnnotationTLS, r.TLS)
+		anno, err := tls.Do(ctx, []byte(test.FactoryRandomFixedLengthString(1024, test.AlphanumericCharset)))
+		if err != nil {
+			t.Error(err)
+		}
+		b, _ := json.Marshal(anno)
+		w.Write(b)
+	}))
+	defer ts.Close()
+
+	client := ts.Client()
+	result, err := client.Get(ts.URL)
+	if err != nil {
+		t.Error(err)
+	} else {
+		defer result.Body.Close()
+		var a contracts.Annotation
+		body, _ := io.ReadAll(result.Body)
+		json.Unmarshal(body, &a)
+		if a.IsSatisfied {
+			t.Error("annotation.IsSatisfied should be false")
+		}
+	}
+}

--- a/pkg/contracts/constants.go
+++ b/pkg/contracts/constants.go
@@ -62,11 +62,12 @@ type AnnotationType string
 const (
 	AnnotationPKI    AnnotationType = "pki"
 	AnnotationSource AnnotationType = "src"
+	AnnotationTLS    AnnotationType = "tls"
 	AnnotationTPM    AnnotationType = "tpm"
 )
 
 func (t AnnotationType) Validate() bool {
-	if t == AnnotationPKI || t == AnnotationTPM || t == AnnotationSource {
+	if t == AnnotationPKI || t == AnnotationTLS || t == AnnotationTPM || t == AnnotationSource {
 		return true
 	}
 	return false


### PR DESCRIPTION
Fix #11

Currently only recommended for annotating TLS support for HTTP. Support for
pub-sub will most likely be added later after some more consideration.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>