### PR TITLE
Adding YAML support for SDK configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,18 @@
 module github.com/project-alvarium/alvarium-sdk-go
 
-go 1.16
+go 1.20
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/eclipse/paho.mqtt.golang v1.3.5
 	github.com/oklog/ulid/v2 v2.0.2
 	github.com/project-alvarium/provider-logging v0.0.0-20210720200405-d8d2146a4f14
 	github.com/stretchr/testify v1.7.0
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -24,5 +24,5 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/mock/publisher.go
+++ b/internal/mock/publisher.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,6 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package mock
 
 import (
@@ -21,11 +22,11 @@ import (
 )
 
 type mockPublisher struct {
-	cfg    config.IotaStreamConfig
+	cfg    config.MockStreamConfig
 	logger logInterface.Logger
 }
 
-func NewMockPublisher(cfg config.IotaStreamConfig, logger logInterface.Logger) (interfaces.StreamProvider, error) {
+func NewMockPublisher(cfg config.MockStreamConfig, logger logInterface.Logger) (interfaces.StreamProvider, error) {
 	return &mockPublisher{
 		cfg:    cfg,
 		logger: logger,

--- a/pkg/config/hash.go
+++ b/pkg/config/hash.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,16 +11,18 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package config
 
 import (
 	"encoding/json"
 	"fmt"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/contracts"
+	"gopkg.in/yaml.v3"
 )
 
 type HashInfo struct {
-	Type contracts.HashType `json:"type,omitempty"`
+	Type contracts.HashType `json:"type,omitempty" yaml:"type"`
 }
 
 func (h *HashInfo) UnmarshalJSON(data []byte) (err error) {
@@ -30,6 +32,23 @@ func (h *HashInfo) UnmarshalJSON(data []byte) (err error) {
 
 	a := Alias{}
 	if err = json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+
+	if !a.Type.Validate() {
+		return fmt.Errorf("invalid HashType value provided %s", a.Type)
+	}
+	h.Type = a.Type
+	return nil
+}
+
+func (h *HashInfo) UnmarshalYAML(data *yaml.Node) (err error) {
+	type Alias struct {
+		Type contracts.HashType `yaml:"type"`
+	}
+
+	a := Alias{}
+	if err = data.Decode(&a); err != nil {
 		return err
 	}
 

--- a/pkg/config/sign.go
+++ b/pkg/config/sign.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,22 +11,24 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package config
 
 import (
 	"encoding/json"
 	"fmt"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/contracts"
+	"gopkg.in/yaml.v3"
 )
 
 type SignatureInfo struct {
-	PublicKey  KeyInfo `json:"public,omitempty"`
-	PrivateKey KeyInfo `json:"private,omitempty"`
+	PublicKey  KeyInfo `json:"public,omitempty" yaml:"public"`
+	PrivateKey KeyInfo `json:"private,omitempty" yaml:"private"`
 }
 
 type KeyInfo struct {
-	Type contracts.KeyAlgorithm `json:"type,omitempty"` // Type indicates the algorithm used to generate the key
-	Path string                 `json:"path,omitempty"` // Path indicates the filesystem path to the key.
+	Type contracts.KeyAlgorithm `json:"type,omitempty" yaml:"type"` // Type indicates the algorithm used to generate the key
+	Path string                 `json:"path,omitempty" yaml:"path"` // Path indicates the filesystem path to the key.
 	// Path will need to be extended later. Consider that keys may be sourced from difference locations -- file, TPM,
 	// Vault, etc.
 }
@@ -39,6 +41,26 @@ func (k *KeyInfo) UnmarshalJSON(data []byte) (err error) {
 	a := Alias{}
 	// Error with unmarshaling
 	if err = json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+
+	if !a.Type.Validate() {
+		return fmt.Errorf("invalid KeyAlgorithm value provided %s", a.Type)
+	}
+	k.Type = a.Type
+	k.Path = a.Path
+
+	return nil
+}
+
+func (k *KeyInfo) UnmarshalYAML(data *yaml.Node) (err error) {
+	type Alias struct {
+		Type contracts.KeyAlgorithm `yaml:"type"`
+		Path string                 `yaml:"path"`
+	}
+	a := Alias{}
+	// Error with unmarshaling
+	if err = data.Decode(&a); err != nil {
 		return err
 	}
 

--- a/pkg/config/stream.go
+++ b/pkg/config/stream.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,18 +11,20 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package config
 
 import (
 	"encoding/json"
 	"fmt"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/contracts"
+	"gopkg.in/yaml.v3"
 )
 
 // StreamInfo facilitates configuration of a given streaming platform that will receive annotations
 type StreamInfo struct {
-	Type   contracts.StreamType `json:"type,omitempty"`
-	Config interface{}          `json:"config,omitempty"`
+	Type   contracts.StreamType `json:"type,omitempty" yaml:"type"`
+	Config interface{}          `json:"config,omitempty" yaml:"config"`
 }
 
 func (s *StreamInfo) UnmarshalJSON(data []byte) (err error) {
@@ -39,7 +41,7 @@ func (s *StreamInfo) UnmarshalJSON(data []byte) (err error) {
 		return fmt.Errorf("invalid StreamType value provided %s", a.Type)
 	}
 
-	if a.Type == contracts.IotaStream || a.Type == contracts.MockStream {
+	if a.Type == contracts.IotaStream {
 		type iotaAlias struct {
 			Type   contracts.StreamType `json:"type,omitempty"`
 			Config IotaStreamConfig     `json:"config,omitempty"`
@@ -65,6 +67,77 @@ func (s *StreamInfo) UnmarshalJSON(data []byte) (err error) {
 		}
 		s.Type = m.Type
 		s.Config = m.Config
+	} else if a.Type == contracts.MockStream {
+		type mockAlias struct {
+			Type   contracts.StreamType `json:"type,omitempty"`
+			Config MockStreamConfig     `json:"config,omitempty"`
+		}
+		m := mockAlias{}
+		//Error with unmarshaling
+		if err = json.Unmarshal(data, &m); err != nil {
+			return err
+		}
+		s.Type = m.Type
+		s.Config = m.Config
+	} else {
+		return fmt.Errorf("unhandled StreamInfo.Type value %s", a.Type)
+	}
+
+	return nil
+}
+
+func (s *StreamInfo) UnmarshalYAML(data *yaml.Node) (err error) {
+	type Alias struct {
+		Type contracts.StreamType `yaml:"type"`
+	}
+	a := Alias{}
+	// Error with unmarshaling
+	if err = data.Decode(&a); err != nil {
+		return err
+	}
+
+	if !a.Type.Validate() {
+		return fmt.Errorf("invalid StreamType value provided %s", a.Type)
+	}
+
+	if a.Type == contracts.IotaStream {
+		type iotaAlias struct {
+			Type   contracts.StreamType `yaml:"type"`
+			Config IotaStreamConfig     `yaml:"config"`
+		}
+
+		i := iotaAlias{}
+		// Error with unmarshaling
+		if err = data.Decode(&i); err != nil {
+			return err
+		}
+		s.Type = i.Type
+		s.Config = i.Config
+	} else if a.Type == contracts.MqttStream {
+		type mqttAlias struct {
+			Type   contracts.StreamType `yaml:"type"`
+			Config MqttConfig           `yaml:"config"`
+		}
+
+		m := mqttAlias{}
+		//Error with unmarshaling
+		if err = data.Decode(&m); err != nil {
+			return err
+		}
+		s.Type = m.Type
+		s.Config = m.Config
+	} else if a.Type == contracts.MockStream {
+		type mockAlias struct {
+			Type   contracts.StreamType `yaml:"type"`
+			Config MockStreamConfig     `yaml:"config"`
+		}
+		m := mockAlias{}
+		//Error with unmarshaling
+		if err = data.Decode(&m); err != nil {
+			return err
+		}
+		s.Type = m.Type
+		s.Config = m.Config
 	} else {
 		return fmt.Errorf("unhandled StreamInfo.Type value %s", a.Type)
 	}
@@ -74,28 +147,33 @@ func (s *StreamInfo) UnmarshalJSON(data []byte) (err error) {
 
 // IotaStreamConfig exposes properties relevant to connecting to an existing IOTA Stream and accompanying Tangle node
 type IotaStreamConfig struct {
-	Provider   ServiceInfo `json:"provider,omitempty"` // Provider is the endpoint from which the Streams subscription is obtained
-	TangleNode ServiceInfo `json:"tangle,omitempty"`   // TangleNode is the endpoint of the local Hornet instance. Transactions are written here.
-	Encoding   string      `json:"encoding,omitempty"` // Encoding specifies the encoding of transaction messages
+	Provider   ServiceInfo `json:"provider,omitempty" yaml:"provider"` // Provider is the endpoint from which the Streams subscription is obtained
+	TangleNode ServiceInfo `json:"tangle,omitempty" yaml:"tangle"`     // TangleNode is the endpoint of the local Hornet instance. Transactions are written here.
+	Encoding   string      `json:"encoding,omitempty" yaml:"encoding"` // Encoding specifies the encoding of transaction messages
 }
 
 // MqttConfig exposes properties relevant to connecting to an existing MQTT broker
 type MqttConfig struct {
-	ClientId  string      `json:"clientId,omitempty"`
-	Qos       int         `json:"qos,omitempty"`
-	User      string      `json:"user,omitempty"`
-	Password  string      `json:"password,omitempty"`
-	Provider  ServiceInfo `json:"provider,omitempty"`
-	Cleanness bool        `json:"cleanness,omitempty"`
-	Topics    []string    `json:"topics,omitempty"`
+	ClientId  string      `json:"clientId,omitempty" yaml:"clientId"`
+	Qos       int         `json:"qos,omitempty" yaml:"qos"`
+	User      string      `json:"user,omitempty" yaml:"user"`
+	Password  string      `json:"password,omitempty" yaml:"password"`
+	Provider  ServiceInfo `json:"provider,omitempty" yaml:"provider"`
+	Cleanness bool        `json:"cleanness,omitempty" yaml:"cleanness"`
+	Topics    []string    `json:"topics,omitempty" yaml:"topics"`
+}
+
+// MockStreamConfig exposes properties to simulate a stream connection for testing.
+type MockStreamConfig struct {
+	Provider ServiceInfo `json:"provider,omitempty" yaml:"provider"`
 }
 
 // ServiceInfo describes a service endpoint that the deployed service is a client of. Right now, this is implicitly
 // an HTTP interaction
 type ServiceInfo struct {
-	Host     string `json:"host,omitempty"`
-	Port     int    `json:"port,omitempty"`
-	Protocol string `json:"protocol,omitempty"`
+	Host     string `json:"host,omitempty" yaml:"host"`
+	Port     int    `json:"port,omitempty" yaml:"port"`
+	Protocol string `json:"protocol,omitempty" yaml:"protocol"`
 }
 
 // Uri constructs a string from the populated elements of the ServiceInfo

--- a/pkg/factories/factory.go
+++ b/pkg/factories/factory.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -40,7 +40,7 @@ func NewStreamProvider(cfg config.StreamInfo, logger logInterface.Logger) (inter
 		}
 		return iota.NewIotaPublisher(info, logger)
 	case contracts.MockStream:
-		info, ok := cfg.Config.(config.IotaStreamConfig)
+		info, ok := cfg.Config.(config.MockStreamConfig)
 		if !ok {
 			return nil, errors.New("invalid cast for MockStream")
 		}

--- a/pkg/factories/factory_test.go
+++ b/pkg/factories/factory_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -38,7 +38,7 @@ func TestStreamProviderFactory(t *testing.T) {
 
 	pass2 := config.StreamInfo{
 		Type:   contracts.MockStream,
-		Config: config.IotaStreamConfig{},
+		Config: config.MockStreamConfig{},
 	}
 
 	pass3 := config.StreamInfo{

--- a/test/res/config.json
+++ b/test/res/config.json
@@ -14,19 +14,13 @@
     }
   },
   "stream": {
-    "type": "iota",
+    "type": "mock",
     "config": {
       "provider": {
         "host": "localhost",
         "protocol": "http",
         "port": 8080
-      },
-      "tangle": {
-        "host": "localhost",
-        "protocol": "http",
-        "port": 8080
-      },
-      "encoding": "utf-8"
+      }
     }
   }
 }

--- a/test/res/config.yaml
+++ b/test/res/config.yaml
@@ -1,0 +1,19 @@
+annotators:
+  - tpm
+  - pki
+hash:
+  type: "sha256"
+signature:
+  public:
+    type: "ed25519"
+    path: "../../test/keys/ed25519/public.key"
+  private:
+    type: "ed25519"
+    path: "../../test/keys/ed25519/private.key"
+stream:
+  type: "mock"
+  config:
+    provider:
+      host: "localhost"
+      protocol: "http"
+      port: 8080


### PR DESCRIPTION
Fix #41
Fix #40

This PR adds support for YAML format in defining SDK configuration. This is a required change for integration with EdgeX Foundry as of their new 3.0 release.

I do not like the duplicated boilerplate introduced by this PR and thought for some time about how I might reduce it. Since I was unable for the moment to devise an elegant solution, I am leaving this as-is for now in the hopes some clarity will be forthcoming later.

Two issues I wrestled with in trying to devise a better plan are:
* I do not want to pollute the package with a bunch of globally defined "alias" types used during unmarshaling
* The manner in which JSON/YAML are unmarshaled is just different enough to be problematic. It would be nice if the interfaces behaved the same. Instead, some "flag" parameter would need to be passed around to indicate to the unmarshal "wrapper" helper method which should be used.

All unit tests pass.