### PR TITLE
Add slog based logger package

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The SDK provides a minimal API -- NewSdk(), Create(), Mutate(), Transit(), Publi
 ### NewSdk()
 
 ```go
-func NewSdk(annotators []annotator.Contract, cfg config.SdkInfo, logger logInterface.Logger) interfaces.Sdk
+func NewSdk(annotators []annotator.Contract, cfg config.SdkInfo, logger interfaces.Logger) interfaces.Sdk
 ```
 
 Used to instantiate a new SDK instance with the specified list of annotators.

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/project-alvarium/alvarium-sdk-go
 
-go 1.20
+go 1.21
 
 require (
 	github.com/eclipse/paho.mqtt.golang v1.3.5
 	github.com/oklog/ulid/v2 v2.0.2
-	github.com/project-alvarium/provider-logging v0.0.0-20210720200405-d8d2146a4f14
 	github.com/stretchr/testify v1.7.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -14,5 +14,4 @@ require (
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/oklog/ulid/v2 v2.0.2/go.mod h1:mtBL0Qe/0HAx6/a4Z30qxVIAL1eQDweXq5lxOE
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/project-alvarium/provider-logging v0.0.0-20210720200405-d8d2146a4f14 h1:4fwmK78itC3d8CMcwUHSHmzKEk84g8GrqHk5j0VBCS4=
-github.com/project-alvarium/provider-logging v0.0.0-20210720200405-d8d2146a4f14/go.mod h1:25HpPXwSpStTsQExg995vhsYgB0mBto2m/F9DibbqCc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/internal/mqtt/publisher.go
+++ b/internal/mqtt/publisher.go
@@ -16,13 +16,13 @@ package mqtt
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
+	"time"
+
 	MQTT "github.com/eclipse/paho.mqtt.golang"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/config"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/interfaces"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/message"
-	logInterface "github.com/project-alvarium/provider-logging/pkg/interfaces"
-	"github.com/project-alvarium/provider-logging/pkg/logging"
-	"time"
 )
 
 const (
@@ -32,11 +32,11 @@ const (
 
 type mqttPublisher struct {
 	endpoint   config.MqttConfig
-	logger     logInterface.Logger
+	logger     interfaces.Logger
 	mqttClient MQTT.Client
 }
 
-func NewMqttPublisher(cfg config.MqttConfig, logger logInterface.Logger) interfaces.StreamProvider {
+func NewMqttPublisher(cfg config.MqttConfig, logger interfaces.Logger) interfaces.StreamProvider {
 	opts := MQTT.NewClientOptions()
 	opts.AddBroker(cfg.Provider.Uri())
 	opts.SetClientID(cfg.ClientId)
@@ -68,7 +68,7 @@ func (p *mqttPublisher) Publish(msg message.PublishWrapper) error {
 	b, _ := json.Marshal(msg)
 	// publish to all topics
 	for _, topic := range p.endpoint.Topics {
-		p.logger.Write(logging.DebugLevel, fmt.Sprintf("attempting publish, topic %s %s", topic, string(b)))
+		p.logger.Write(slog.LevelDebug, fmt.Sprintf("attempting publish, topic %s %s", topic, string(b)))
 		token := p.mqttClient.Publish(topic, byte(p.endpoint.Qos), false, b)
 		token.WaitTimeout(time.Millisecond * publishTimeout)
 	}

--- a/pkg/config/sdk.go
+++ b/pkg/config/sdk.go
@@ -17,6 +17,8 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
+
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/contracts"
 	"gopkg.in/yaml.v3"
 )
@@ -26,6 +28,10 @@ type SdkInfo struct {
 	Hash       HashInfo                   `json:"hash,omitempty" yaml:"hash"`
 	Signature  SignatureInfo              `json:"signature,omitempty" yaml:"signature"`
 	Stream     StreamInfo                 `json:"stream,omitempty" yaml:"stream"`
+}
+
+type LoggingInfo struct {
+	MinLogLevel slog.Level `json:"minLogLevel,omitempty"`
 }
 
 func (s *SdkInfo) UnmarshalJSON(data []byte) (err error) {

--- a/pkg/factories/factory.go
+++ b/pkg/factories/factory.go
@@ -27,10 +27,10 @@ import (
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/config"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/contracts"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/interfaces"
-	logInterface "github.com/project-alvarium/provider-logging/pkg/interfaces"
+	"github.com/project-alvarium/alvarium-sdk-go/pkg/logging"
 )
 
-func NewStreamProvider(cfg config.StreamInfo, logger logInterface.Logger) (interfaces.StreamProvider, error) {
+func NewStreamProvider(cfg config.StreamInfo, logger interfaces.Logger) (interfaces.StreamProvider, error) {
 	switch cfg.Type {
 	case contracts.MockStream:
 		info, ok := cfg.Config.(config.MockStreamConfig)
@@ -78,4 +78,8 @@ func NewRequestHandler(request *http.Request, keys config.SignatureInfo) (interf
 		return nil, fmt.Errorf("unrecognized Key Type %s", keys.PrivateKey.Type)
 	}
 	return r, nil
+}
+
+func NewLogger(cfg config.LoggingInfo) interfaces.Logger {
+	return logging.NewConsoleLogger(cfg)
 }

--- a/pkg/factories/factory_test.go
+++ b/pkg/factories/factory_test.go
@@ -16,20 +16,17 @@ package factories
 import (
 	"bytes"
 	"encoding/json"
+	"log/slog"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/config"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/contracts"
 	"github.com/project-alvarium/alvarium-sdk-go/test"
-	logConfig "github.com/project-alvarium/provider-logging/pkg/config"
-	logFactory "github.com/project-alvarium/provider-logging/pkg/factories"
-	"github.com/project-alvarium/provider-logging/pkg/logging"
 )
 
 func TestStreamProviderFactory(t *testing.T) {
-	logInfo := logConfig.LoggingInfo{MinLogLevel: logging.InfoLevel}
-	logger := logFactory.NewLogger(logInfo)
+	logger := NewLogger(config.LoggingInfo{MinLogLevel: slog.LevelDebug})
 
 	pass := config.StreamInfo{
 		Type:   contracts.MockStream,

--- a/pkg/interfaces/logger.go
+++ b/pkg/interfaces/logger.go
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright 2023 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package interfaces
+
+import "log/slog"
+
+type Logger interface {
+	// Write facilitates creation and writing of a LogEntry of a specified LogLevel. The client application
+	// can also supply a message and a flexible list of additional arguments. These additional arguments are
+	// optional. If provided, they should be treated as a key/value pair where the key is of type LogKey.
+	//
+	// Write flushes the LogEntry to StdOut in JSON format.
+	Write(level slog.Level, message string, args ...any)
+	// Error facilitates creation and writing of a LogEntry at the Error LogLevel. The client application
+	// can also supply a message and a flexible list of additional arguments. These additional arguments are
+	// optional. If provided, they should be treated as a key/value pair where the key is of type LogKey.
+	//
+	// Write flushes the LogEntry to StdErr in JSON format.
+	Error(message string, args ...any)
+}

--- a/pkg/logging/console.go
+++ b/pkg/logging/console.go
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright 2023 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package logging
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"time"
+
+	"github.com/project-alvarium/alvarium-sdk-go/pkg/config"
+)
+
+type ConsoleLogger struct {
+	slog.Logger
+}
+
+func NewConsoleLogger(cfg config.LoggingInfo) ConsoleLogger {
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "unknown"
+	}
+	hostnameAtt := slog.Attr{Key: hostnameAttrKey, Value: slog.StringValue(hostname)}
+
+	level := cfg.MinLogLevel
+	if !isValidLogLevel(level) {
+		level = slog.LevelInfo
+	}
+
+	return ConsoleLogger{
+		Logger: *slog.New(
+			newCustomJsonHandler(level).
+				WithAttrs([]slog.Attr{hostnameAtt}).(*slog.JSONHandler),
+		),
+	}
+}
+
+func (l ConsoleLogger) Write(level slog.Level, message string, args ...any) {
+	if !isValidLogLevel(level) {
+		level = slog.LevelInfo
+	}
+
+	lineAtt := getLineAtt()
+	applicationAtt := getApplicationAtt()
+
+	args = append(args, applicationAtt, lineAtt)
+
+	switch level {
+	case slog.LevelInfo:
+		l.Info(message, args...)
+	case slog.LevelDebug:
+		l.Debug(message, args...)
+	case slog.LevelWarn:
+		l.Warn(message, args...)
+	case slog.LevelError:
+		l.Logger.Error(message, args...)
+	}
+}
+
+func (l ConsoleLogger) Error(message string, args ...any) {
+	lineAtt := getLineAtt()
+	applicationAtt := getApplicationAtt()
+
+	args = append(args, applicationAtt, lineAtt)
+
+	l.Logger.Error(message, args...)
+}
+
+func getLineAtt() slog.Attr {
+	_, file, line, ok := runtime.Caller(2)
+	if !ok {
+		file = "???"
+		line = 0
+	}
+	fileName := filepath.Base(file)
+	return slog.Attr{Key: lineNumberAttrKey, Value: slog.StringValue(fileName + ":" + strconv.Itoa(line))}
+}
+
+func getApplicationAtt() slog.Attr {
+	return slog.Attr{Key: applicationAttrKey, Value: slog.StringValue(os.Args[0])}
+}
+
+func isValidLogLevel(level slog.Level) bool {
+	switch level {
+	case slog.LevelInfo, slog.LevelDebug, slog.LevelWarn, slog.LevelError:
+		return true
+	default:
+		return false
+	}
+}
+
+func newCustomJsonHandler(minLogLevel slog.Level) *slog.JSONHandler {
+	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		AddSource: false,
+		Level:     minLogLevel,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			switch a.Key {
+			case slog.TimeKey:
+				a.Key = "timestamp"
+				inputTime := a.Value.Any().(time.Time)
+				outputTime := inputTime.Format("2006-01-02T15:04:05Z")
+				a.Value = slog.StringValue(outputTime)
+			case slog.MessageKey:
+				a.Key = "message"
+			case slog.LevelKey:
+				a.Key = "log-level"
+				level := a.Value.Any().(slog.Level)
+				a.Value = slog.StringValue(level.String())
+			}
+			return a
+		},
+	})
+	return handler
+}

--- a/pkg/logging/types.go
+++ b/pkg/logging/types.go
@@ -11,35 +11,14 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+package logging
 
-package mock
+type LogKey string
 
-import (
-	"github.com/project-alvarium/alvarium-sdk-go/pkg/config"
-	"github.com/project-alvarium/alvarium-sdk-go/pkg/interfaces"
-	"github.com/project-alvarium/alvarium-sdk-go/pkg/message"
+const (
+	CorrelationKey LogKey = "correlation-id"
+
+	lineNumberAttrKey  = "line-number"
+	applicationAttrKey = "application"
+	hostnameAttrKey    = "hostname"
 )
-
-type mockPublisher struct {
-	cfg    config.MockStreamConfig
-	logger interfaces.Logger
-}
-
-func NewMockPublisher(cfg config.MockStreamConfig, logger interfaces.Logger) (interfaces.StreamProvider, error) {
-	return &mockPublisher{
-		cfg:    cfg,
-		logger: logger,
-	}, nil
-}
-
-func (p *mockPublisher) Connect() error {
-	return nil
-}
-
-func (p *mockPublisher) Publish(msg message.PublishWrapper) error {
-	return nil
-}
-
-func (p *mockPublisher) Close() error {
-	return nil
-}

--- a/pkg/sdk.go
+++ b/pkg/sdk.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/config"
@@ -24,18 +25,16 @@ import (
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/factories"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/interfaces"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/message"
-	logInterface "github.com/project-alvarium/provider-logging/pkg/interfaces"
-	"github.com/project-alvarium/provider-logging/pkg/logging"
 )
 
 type sdk struct {
 	annotators []interfaces.Annotator
 	cfg        config.SdkInfo
 	stream     interfaces.StreamProvider
-	logger     logInterface.Logger
+	logger     interfaces.Logger
 }
 
-func NewSdk(annotators []interfaces.Annotator, cfg config.SdkInfo, logger logInterface.Logger) interfaces.Sdk {
+func NewSdk(annotators []interfaces.Annotator, cfg config.SdkInfo, logger interfaces.Logger) interfaces.Sdk {
 	instance := sdk{
 		annotators: annotators,
 		cfg:        cfg,
@@ -57,14 +56,14 @@ func (s *sdk) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup) bool {
 		s.logger.Error(err.Error())
 		return false
 	}
-	s.logger.Write(logging.DebugLevel, "stream provider connection successful")
+	s.logger.Write(slog.LevelDebug, "stream provider connection successful")
 
 	wg.Add(1)
 	go func() { // Graceful shutdown
 		defer wg.Done()
 
 		<-ctx.Done()
-		s.logger.Write(logging.InfoLevel, "shutdown received")
+		s.logger.Write(slog.LevelInfo, "shutdown received")
 		s.stream.Close()
 	}()
 	return true

--- a/pkg/sdk_test.go
+++ b/pkg/sdk_test.go
@@ -16,24 +16,21 @@ package pkg
 import (
 	"context"
 	"encoding/json"
-	"gopkg.in/yaml.v3"
+	"log/slog"
 	"os"
 	"sync"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/config"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/contracts"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/factories"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/interfaces"
-	logConfig "github.com/project-alvarium/provider-logging/pkg/config"
-	logFactory "github.com/project-alvarium/provider-logging/pkg/factories"
-	logInterface "github.com/project-alvarium/provider-logging/pkg/interfaces"
-	"github.com/project-alvarium/provider-logging/pkg/logging"
 )
 
 func TestNewSdkJson(t *testing.T) {
-	logInfo := logConfig.LoggingInfo{MinLogLevel: logging.InfoLevel}
-	logger := logFactory.NewLogger(logInfo)
+	logger := factories.NewLogger(config.LoggingInfo{MinLogLevel: slog.LevelInfo})
 
 	b, err := os.ReadFile("../test/res/config.json")
 	if err != nil {
@@ -54,7 +51,7 @@ func TestNewSdkJson(t *testing.T) {
 	tests := []struct {
 		name         string
 		cfg          config.SdkInfo
-		log          logInterface.Logger
+		log          interfaces.Logger
 		expectResult bool
 	}{
 		{"new sdk valid params", pass, logger, true},
@@ -83,8 +80,7 @@ func TestNewSdkJson(t *testing.T) {
 }
 
 func TestNewSdkYaml(t *testing.T) {
-	logInfo := logConfig.LoggingInfo{MinLogLevel: logging.InfoLevel}
-	logger := logFactory.NewLogger(logInfo)
+	logger := factories.NewLogger(config.LoggingInfo{MinLogLevel: slog.LevelInfo})
 
 	b, err := os.ReadFile("../test/res/config.yaml")
 	if err != nil {
@@ -105,7 +101,7 @@ func TestNewSdkYaml(t *testing.T) {
 	tests := []struct {
 		name         string
 		cfg          config.SdkInfo
-		log          logInterface.Logger
+		log          interfaces.Logger
 		expectResult bool
 	}{
 		{"new sdk valid params", pass, logger, true},


### PR DESCRIPTION
Fix #45

- Added Logger interface
- Added a new ```Logger``` struct in ```logger.go``` that wraps the standard ```slog``` logger with our custom format and added functionality.
- Replicated the [provider-logging](https://github.com/project-alvarium/provider-logging) ```Logger``` functionalities and signatures
- The logger supports different log levels: Trace, Info, Debug, Warn, and Error
- Changed all ```provider-logging``` imports to the new ```logging``` package
- Sample logs: 
```{"timestamp":"2023-12-11T14:28:39Z","log-level":"trace","message":"This is a trace message","hostname":"DESKTOP-0QCUII1","application":"/tmp/go-build4235426231/b001/exe/main","line-number":"main.go:8"}
{"timestamp":"2023-12-11T14:28:39Z","log-level":"info","message":"This is an info message","hostname":"DESKTOP-0QCUII1","application":"/tmp/go-build4235426231/b001/exe/main","line-number":"main.go:9"}
{"timestamp":"2023-12-11T14:28:39Z","log-level":"debug","message":"This is a debug message","hostname":"DESKTOP-0QCUII1","application":"/tmp/go-build4235426231/b001/exe/main","line-number":"main.go:10"}
{"timestamp":"2023-12-11T14:28:39Z","log-level":"warn","message":"This is a warning message","hostname":"DESKTOP-0QCUII1","application":"/tmp/go-build4235426231/b001/exe/main","line-number":"main.go:11"}
{"timestamp":"2023-12-11T14:28:39Z","log-level":"error","message":"This is an error message","hostname":"DESKTOP-0QCUII1","application":"/tmp/go-build4235426231/b001/exe/main","line-number":"main.go:12"}
```

Only issue I'm facing now is the order of the key, value pairs in each log entry. The key value pairs are stored as a map therefore can't keep a custom order. Looking into the Python and Java SDKs to see if we can conform the order above in their respective logs.

Note: I carried out the application attribute generation when calling ```Logger.Write``` or ```.Error``` considering the value may varry from a logging instance to another but I am not sure if it's a constant for each logger instance itself it'd be moved to the ```Logger``` constructor instead.