### PR TITLE
Add CI/CD annotator types to contracts and refactor code

### DIFF
--- a/pkg/contracts/constants.go
+++ b/pkg/contracts/constants.go
@@ -74,10 +74,12 @@ const (
 )
 
 func (t AnnotationType) Validate() bool {
-	if t == AnnotationPKI || t == AnnotationTLS || t == AnnotationTPM || t == AnnotationSource || t == AnnotationPKIHttp || t == AnnotationSourceCode || t == AnnotationChecksum || t == AnnotationVulnerability {
+	switch t {
+	case AnnotationPKI, AnnotationTLS, AnnotationTPM, AnnotationSource, AnnotationPKIHttp, AnnotationSourceCode, AnnotationChecksum, AnnotationVulnerability:
 		return true
+	default:
+		return false
 	}
-	return false
 }
 
 type DerivedComponent string

--- a/pkg/contracts/constants.go
+++ b/pkg/contracts/constants.go
@@ -62,15 +62,18 @@ func (t StreamType) Validate() bool {
 type AnnotationType string
 
 const (
-	AnnotationPKI     AnnotationType = "pki"
-	AnnotationPKIHttp AnnotationType = "pki-http"
-	AnnotationSource  AnnotationType = "src"
-	AnnotationTLS     AnnotationType = "tls"
-	AnnotationTPM     AnnotationType = "tpm"
+	AnnotationPKI           AnnotationType = "pki"
+	AnnotationPKIHttp       AnnotationType = "pki-http"
+	AnnotationSource        AnnotationType = "src"
+	AnnotationTLS           AnnotationType = "tls"
+	AnnotationTPM           AnnotationType = "tpm"
+	AnnotationSourceCode    AnnotationType = "source-code"
+	AnnotationChecksum      AnnotationType = "checksum"
+	AnnotationVulnerability AnnotationType = "vulnerability"
 )
 
 func (t AnnotationType) Validate() bool {
-	if t == AnnotationPKI || t == AnnotationTLS || t == AnnotationTPM || t == AnnotationSource || t == AnnotationPKIHttp {
+	if t == AnnotationPKI || t == AnnotationTLS || t == AnnotationTPM || t == AnnotationSource || t == AnnotationPKIHttp || t == AnnotationSourceCode || t == AnnotationChecksum || t == AnnotationVulnerability {
 		return true
 	}
 	return false

--- a/pkg/contracts/constants.go
+++ b/pkg/contracts/constants.go
@@ -62,11 +62,12 @@ func (t StreamType) Validate() bool {
 type AnnotationType string
 
 const (
-	AnnotationPKI           AnnotationType = "pki"
-	AnnotationPKIHttp       AnnotationType = "pki-http"
-	AnnotationSource        AnnotationType = "src"
-	AnnotationTLS           AnnotationType = "tls"
-	AnnotationTPM           AnnotationType = "tpm"
+	AnnotationPKI     AnnotationType = "pki"
+	AnnotationPKIHttp AnnotationType = "pki-http"
+	AnnotationSource  AnnotationType = "src"
+	AnnotationTLS     AnnotationType = "tls"
+	AnnotationTPM     AnnotationType = "tpm"
+	// The AnnotationSourceCode, AnnotationChecksum, and AnnotationVulnerability values are used by the scoring apps, they are for CI/CD annotators defined in alvarium-sdk-java project.
 	AnnotationSourceCode    AnnotationType = "source-code"
 	AnnotationChecksum      AnnotationType = "checksum"
 	AnnotationVulnerability AnnotationType = "vulnerability"


### PR DESCRIPTION
Fix #49 
This pull request adds the CI/CD types of annotations to the alvarium-sdk-go contracts. These types are “source-code”, “vulnerability”, and “checksum”. They are used by the scoring apps to handle annotations produced by a Jenkins pipeline.
It also refactors the AnnotationType Validate function to improve the readability and maintainability of the code.