### PR TITLE
Externalize Signing and Hashing Providers

### DIFF
--- a/internal/annotators/base.go
+++ b/internal/annotators/base.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2024 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,82 +11,37 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package annotators
 
 import (
 	"encoding/json"
-	"fmt"
-	"github.com/project-alvarium/alvarium-sdk-go/internal/hashprovider"
-	"github.com/project-alvarium/alvarium-sdk-go/internal/hashprovider/md5"
-	"github.com/project-alvarium/alvarium-sdk-go/internal/hashprovider/none"
-	"github.com/project-alvarium/alvarium-sdk-go/internal/hashprovider/sha256"
-	"github.com/project-alvarium/alvarium-sdk-go/internal/signprovider"
-	"github.com/project-alvarium/alvarium-sdk-go/internal/signprovider/ed25519"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/config"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/contracts"
-	"io/ioutil"
+	"github.com/project-alvarium/alvarium-sdk-go/pkg/interfaces"
 )
 
-func DeriveHash(hash contracts.HashType, data []byte) string {
-	var h hashprovider.Provider
-	switch hash {
-	case contracts.MD5Hash:
-		h = md5.New()
-	case contracts.SHA256Hash:
-		h = sha256.New()
-	default:
-		h = none.New()
-	}
-
-	return h.Derive(data)
-}
-
-func SignAnnotation(key config.KeyInfo, a contracts.Annotation) (string, error) {
-	var s signprovider.Provider
-	switch key.Type {
-	case contracts.KeyEd25519:
-		s = ed25519.New()
-	default:
-		return "", fmt.Errorf("unrecognized key type %s", key.Type)
-	}
-
+func SignAnnotation(key config.KeyInfo, signature interfaces.SignatureProvider, a contracts.Annotation) (string, error) {
 	b, err := json.Marshal(a)
 	if err != nil {
 		return "", err
 	}
 
-	prv, err := ioutil.ReadFile(key.Path)
-	if err != nil {
-		return "", err
-	}
-
-	signed := s.Sign(prv, b)
-	return signed, nil
+	return signature.Sign(key, b)
 }
 
-func VerifySignature(key config.KeyInfo, src contracts.Annotation) (bool, error) {
-	var s signprovider.Provider
-	switch key.Type {
-	case contracts.KeyEd25519:
-		s = ed25519.New()
-	default:
-		return false, fmt.Errorf("unrecognized key type %s", key.Type)
-	}
-
+// VerifySignature will validate the signature on an Annotation
+//
+// Currently (29-Mar-2024) this method is only used by unit tests
+func VerifySignature(key config.KeyInfo, signature interfaces.SignatureProvider, src contracts.Annotation) (bool, error) {
 	// Annotations are signed based on their JSON representation prior to populating the Signature property.
 	// Thus we need to reflect that prior state by setting the Signature property to empty before marshalling
-	signature := src.Signature
+	verifiable := src.Signature
 	src.Signature = ""
 	b, err := json.Marshal(src)
 	if err != nil {
 		return false, err
 	}
 
-	pub, err := ioutil.ReadFile(key.Path)
-	if err != nil {
-		return false, err
-	}
-
-	ok := s.Verify(pub, b, []byte(signature))
-	return ok, nil
+	return signature.Verify(key, b, []byte(verifiable))
 }

--- a/internal/annotators/base_test.go
+++ b/internal/annotators/base_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2024 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,8 +15,13 @@ package annotators
 
 import (
 	"encoding/json"
+	"github.com/project-alvarium/alvarium-sdk-go/internal/hashprovider/md5"
+	"github.com/project-alvarium/alvarium-sdk-go/internal/hashprovider/none"
+	sha2562 "github.com/project-alvarium/alvarium-sdk-go/internal/hashprovider/sha256"
+	"github.com/project-alvarium/alvarium-sdk-go/internal/signprovider/ed25519"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/config"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/contracts"
+	"github.com/project-alvarium/alvarium-sdk-go/pkg/interfaces"
 	"github.com/project-alvarium/alvarium-sdk-go/test"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -25,27 +30,30 @@ import (
 func TestDeriveHash(t *testing.T) {
 	noneInput := test.FactoryRandomFixedLengthString(64, test.AlphanumericCharset)
 	noneOutput := noneInput
+	noHash := none.New()
 
 	md5Input := []byte("foo")
 	md5Output := "acbd18db4cc2f85cedef654fccc4a4d8"
+	md5Hash := md5.New()
 
 	sha256Input := []byte("bar")
 	sha256Output := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+	sha256Hash := sha2562.New()
 
 	tests := []struct {
-		name     string
-		hashType contracts.HashType
-		input    []byte
-		output   string
+		name         string
+		hashType     contracts.HashType
+		hashProvider interfaces.HashProvider
+		input        []byte
+		output       string
 	}{
-		{"derive no hash", contracts.NoHash, []byte(noneInput), noneOutput},
-		{"derive md5 hash", contracts.MD5Hash, md5Input, md5Output},
-		{"derive sha256 hash", contracts.SHA256Hash, sha256Input, sha256Output},
-		{"default to none", "invalid", []byte(noneInput), noneOutput},
+		{"derive no hash", contracts.NoHash, noHash, []byte(noneInput), noneOutput},
+		{"derive md5 hash", contracts.MD5Hash, md5Hash, md5Input, md5Output},
+		{"derive sha256 hash", contracts.SHA256Hash, sha256Hash, sha256Input, sha256Output},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := DeriveHash(tt.hashType, tt.input)
+			result := tt.hashProvider.Derive(tt.input)
 			assert.Equal(t, tt.output, result)
 		})
 	}
@@ -55,11 +63,6 @@ func TestSignAnnotation(t *testing.T) {
 	private := config.KeyInfo{
 		Type: contracts.KeyEd25519,
 		Path: "../../test/keys/ed25519/private.key",
-	}
-
-	invalid := config.KeyInfo{
-		Type: "invalid",
-		Path: "",
 	}
 
 	//I'm using a JSON representation here b/c calling the Annotation constructor will populate different ID and Timestamp values each time.
@@ -73,15 +76,20 @@ func TestSignAnnotation(t *testing.T) {
 		cfg         config.KeyInfo
 		annotation  contracts.Annotation
 		signature   string
+		sigProvider interfaces.SignatureProvider
 		expectError bool
 	}{
-		{"valid ed25519 signature", private, a, "dafcee0a1844b9c5c0db87252067afc06853afefa14b1711a7c24a6eabc6f6b76b91f8aae2ce54f74b54500dbaf303fbb23dc550e151cfe03cef68ae26a22306", false},
-		{"invalid key type", invalid, a, "abcdef", true},
+		{"valid ed25519 signature", private, a,
+			"dafcee0a1844b9c5c0db87252067afc06853afefa14b1711a7c24a6eabc6f6b76b91f8aae2ce54f74b54500dbaf303fbb23dc550e151cfe03cef68ae26a22306",
+			ed25519.New(), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := SignAnnotation(tt.cfg, tt.annotation)
-			test.CheckError(err, tt.expectError, tt.name, t)
+			b, err := json.Marshal(tt.annotation)
+			if err != nil {
+				t.Error(err)
+			}
+			result, err := tt.sigProvider.Sign(tt.cfg, b)
 
 			if err == nil {
 				assert.Equal(t, tt.signature, result)

--- a/internal/annotators/http/handler/ed25519.go
+++ b/internal/annotators/http/handler/ed25519.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2022 Dell Inc.
+ * Copyright 2024 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,7 +16,6 @@ package http
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -64,12 +63,7 @@ func (h *requestHandler) AddSignatureHeaders(ticks time.Time, fields []string, k
 	inputValue = parsed.Seed
 
 	p := ed25519.New()
-	prv, err := ioutil.ReadFile(keys.PrivateKey.Path)
-	if err != nil {
-		return err
-	}
-
-	signature := p.Sign(prv, []byte(inputValue))
+	signature, err := p.Sign(keys.PrivateKey, []byte(inputValue))
 
 	h.Request.Header.Set("Signature", signature)
 	return nil

--- a/internal/annotators/http/handler/ed25519_test.go
+++ b/internal/annotators/http/handler/ed25519_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2022 Dell Inc.
+ * Copyright 2024 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,9 +17,9 @@ package http
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -31,7 +31,7 @@ import (
 )
 
 func TestHttpPkiAnnotator_AddSignatureHeaders(t *testing.T) {
-	b, err := ioutil.ReadFile("./test/config.json")
+	b, err := os.ReadFile("./test/config.json")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/internal/annotators/http/handler/test/config.json
+++ b/internal/annotators/http/handler/test/config.json
@@ -1,4 +1,5 @@
 {
+  "layer": "app",
   "signature": {
     "public": {
       "type": "ed25519",

--- a/internal/annotators/http/pki.go
+++ b/internal/annotators/http/pki.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2022 Dell Inc.
+ * Copyright 2024 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,18 +16,14 @@ package http
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
-	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/project-alvarium/alvarium-sdk-go/internal/annotators"
 	handler "github.com/project-alvarium/alvarium-sdk-go/internal/annotators/http/handler"
-	"github.com/project-alvarium/alvarium-sdk-go/internal/signprovider"
-	"github.com/project-alvarium/alvarium-sdk-go/internal/signprovider/ed25519"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/config"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/contracts"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/interfaces"
@@ -35,23 +31,29 @@ import (
 
 // HttpPkiAnnotator is used to validate whether the signature on a given piece of data is valid, both sent in the HTTP message
 type HttpPkiAnnotator struct {
-	hash  contracts.HashType
-	kind  contracts.AnnotationType
-	sign  config.SignatureInfo
-	layer contracts.LayerType
+	hash      interfaces.HashProvider
+	hashType  contracts.HashType
+	kind      contracts.AnnotationType
+	signature interfaces.SignatureProvider
+	privKey   config.KeyInfo
+	pubKey    config.KeyInfo
+	layer     contracts.LayerType
 }
 
-func NewHttpPkiAnnotator(cfg config.SdkInfo) interfaces.Annotator {
+func NewHttpPkiAnnotator(cfg config.SdkInfo, hash interfaces.HashProvider, sign interfaces.SignatureProvider) interfaces.Annotator {
 	a := HttpPkiAnnotator{}
-	a.hash = cfg.Hash.Type
+	a.hash = hash
+	a.hashType = cfg.Hash.Type
 	a.kind = contracts.AnnotationPKIHttp
-	a.sign = cfg.Signature
+	a.signature = sign
+	a.privKey = cfg.Signature.PrivateKey
+	a.pubKey = cfg.Signature.PublicKey
 	a.layer = cfg.Layer
 	return &a
 }
 
 func (a *HttpPkiAnnotator) Do(ctx context.Context, data []byte) (contracts.Annotation, error) {
-	key := annotators.DeriveHash(a.hash, data)
+	key := a.hash.Derive(data)
 	hostname, _ := os.Hostname()
 
 	//Call parser on request
@@ -67,48 +69,37 @@ func (a *HttpPkiAnnotator) Do(ctx context.Context, data []byte) (contracts.Annot
 
 	// Use the parsed request to obtain the key name and type we should use to validate the signature
 	var k config.KeyInfo
-	directory := filepath.Dir(a.sign.PublicKey.Path)
+	directory := filepath.Dir(a.pubKey.Path)
 	k.Path = strings.Join([]string{directory, parsed.Keyid}, "/")
 	k.Type = contracts.KeyAlgorithm(parsed.Algorithm)
 	if !(k.Type.Validate()) {
 		return contracts.Annotation{}, errors.New("invalid key type specified: " + parsed.Algorithm)
 	}
 
-	ok, err := sig.verifySignature(k)
+	ok, err := sig.verifySignature(k, a.signature)
 	if err != nil {
 		return contracts.Annotation{}, err
 	}
 
-	annotation := contracts.NewAnnotation(string(key), a.hash, hostname, a.layer, a.kind, ok)
-	signed, err := annotators.SignAnnotation(a.sign.PrivateKey, annotation)
+	annotation := contracts.NewAnnotation(string(key), a.hashType, hostname, a.layer, a.kind, ok)
+	b, err := json.Marshal(annotation)
 	if err != nil {
 		return contracts.Annotation{}, err
 	}
-	annotation.Signature = string(signed)
+	signed, err := a.signature.Sign(a.privKey, b)
+	if err != nil {
+		return contracts.Annotation{}, err
+	}
+	annotation.Signature = signed
 	return annotation, nil
 }
 
+// TODO: At this point this type has converged with the one defined in annotators/pki.go. Eliminate duplicate definition
 type signable struct {
 	Seed      string
 	Signature string
 }
 
-func (s *signable) verifySignature(key config.KeyInfo) (bool, error) {
-	if len(s.Signature) == 0 { // no signature detected
-		return false, nil
-	}
-	var p signprovider.Provider
-	switch contracts.KeyAlgorithm(key.Type) {
-	case contracts.KeyEd25519:
-		p = ed25519.New()
-
-	default:
-		return false, fmt.Errorf("unrecognized key type %s", key.Type)
-	}
-	pub, err := ioutil.ReadFile(key.Path)
-	if err != nil {
-		return false, err
-	}
-	ok := p.Verify(pub, []byte(s.Seed), []byte(s.Signature))
-	return ok, nil
+func (s *signable) verifySignature(key config.KeyInfo, signature interfaces.SignatureProvider) (bool, error) {
+	return signature.Verify(key, []byte(s.Seed), []byte(s.Signature))
 }

--- a/internal/annotators/http/test/config.json
+++ b/internal/annotators/http/test/config.json
@@ -1,4 +1,8 @@
 {
+  "layer": "app",
+  "hash": {
+    "type": "sha256"
+  },
   "signature": {
     "public": {
       "type": "ed25519",

--- a/internal/annotators/source.go
+++ b/internal/annotators/source.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2024 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,10 +11,12 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package annotators
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/config"
@@ -24,30 +26,38 @@ import (
 
 // SourceAnnotator is used to provide lineage from one version of data to another as the result of a change or transformation.
 type SourceAnnotator struct {
-	hash  contracts.HashType
-	kind  contracts.AnnotationType
-	sign  config.SignatureInfo
-	layer contracts.LayerType
+	hash      interfaces.HashProvider
+	hashType  contracts.HashType
+	kind      contracts.AnnotationType
+	signature interfaces.SignatureProvider
+	privKey   config.KeyInfo
+	layer     contracts.LayerType
 }
 
-func NewSourceAnnotator(cfg config.SdkInfo) interfaces.Annotator {
+func NewSourceAnnotator(cfg config.SdkInfo, hash interfaces.HashProvider, sign interfaces.SignatureProvider) interfaces.Annotator {
 	a := SourceAnnotator{}
-	a.hash = cfg.Hash.Type
+	a.hash = hash
+	a.hashType = cfg.Hash.Type
 	a.kind = contracts.AnnotationSource
-	a.sign = cfg.Signature
+	a.signature = sign
+	a.privKey = cfg.Signature.PrivateKey
 	a.layer = cfg.Layer
 	return &a
 }
 
 func (a *SourceAnnotator) Do(ctx context.Context, data []byte) (contracts.Annotation, error) {
-	key := DeriveHash(a.hash, data)
+	key := a.hash.Derive(data)
 	hostname, _ := os.Hostname()
 
-	annotation := contracts.NewAnnotation(key, a.hash, hostname, a.layer, a.kind, true)
-	sig, err := SignAnnotation(a.sign.PrivateKey, annotation)
+	annotation := contracts.NewAnnotation(key, a.hashType, hostname, a.layer, a.kind, true)
+	b, err := json.Marshal(annotation)
 	if err != nil {
 		return contracts.Annotation{}, err
 	}
-	annotation.Signature = string(sig)
+	sig, err := a.signature.Sign(a.privKey, b)
+	if err != nil {
+		return contracts.Annotation{}, err
+	}
+	annotation.Signature = sig
 	return annotation, nil
 }

--- a/internal/annotators/tls_test.go
+++ b/internal/annotators/tls_test.go
@@ -1,20 +1,37 @@
+/*******************************************************************************
+ * Copyright 2024 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
 package annotators
 
 import (
 	"context"
 	"encoding/json"
+	hash256 "github.com/project-alvarium/alvarium-sdk-go/internal/hashprovider/sha256"
+	"github.com/project-alvarium/alvarium-sdk-go/internal/signprovider/ed25519"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/config"
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/contracts"
+	"github.com/project-alvarium/alvarium-sdk-go/pkg/interfaces"
 	"github.com/project-alvarium/alvarium-sdk-go/test"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 )
 
 func TestTlsAnnotator_Base(t *testing.T) {
-	b, err := ioutil.ReadFile("../../test/res/config.json")
+	b, err := os.ReadFile("../../test/res/config.json")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -35,24 +52,28 @@ func TestTlsAnnotator_Base(t *testing.T) {
 	keyNotFound.Signature.PrivateKey.Path = "/dev/null/private.key"
 
 	rndString := test.FactoryRandomFixedLengthString(1024, test.AlphanumericCharset)
+	signer := ed25519.New()
+	h := hash256.New()
 	tests := []struct {
 		name        string
 		data        string
 		cfg         config.SdkInfo
+		h           interfaces.HashProvider
+		s           interfaces.SignatureProvider
 		expectError bool
 	}{
-		{"tls annotation OK", rndString, cfg, false},
-		{"tls bad hash type", rndString, badHashType, false}, // returns "none" hash type
-		{"tls bad key type", rndString, badKeyType, true},
-		{"tls key not found", rndString, keyNotFound, true},
+		{"tls annotation OK", rndString, cfg, h, signer, false},
+		{"tls bad hash type", rndString, badHashType, h, signer, false}, // returns "none" hash type
+		{"tls key not found", rndString, keyNotFound, h, signer, true},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tls := NewTlsAnnotator(tt.cfg)
+			tls := NewTlsAnnotator(tt.cfg, tt.h, tt.s)
 			anno, err := tls.Do(context.Background(), []byte(tt.data))
 			test.CheckError(err, tt.expectError, tt.name, t)
 			if err == nil {
-				result, err := VerifySignature(tt.cfg.Signature.PublicKey, anno)
+				result, err := VerifySignature(tt.cfg.Signature.PublicKey, tt.s, anno)
 				if err != nil {
 					t.Error(err.Error())
 				} else if !result {
@@ -64,7 +85,7 @@ func TestTlsAnnotator_Base(t *testing.T) {
 }
 
 func TestTlsAnnotator_ServeTLS(t *testing.T) {
-	b, err := ioutil.ReadFile("../../test/res/config.json")
+	b, err := os.ReadFile("../../test/res/config.json")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -74,7 +95,7 @@ func TestTlsAnnotator_ServeTLS(t *testing.T) {
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	tls := NewTlsAnnotator(cfg)
+	tls := NewTlsAnnotator(cfg, hash256.New(), ed25519.New())
 
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), contracts.AnnotationTLS, r.TLS)
@@ -103,7 +124,7 @@ func TestTlsAnnotator_ServeTLS(t *testing.T) {
 }
 
 func TestTlsAnnotator_Serve(t *testing.T) {
-	b, err := ioutil.ReadFile("../../test/res/config.json")
+	b, err := os.ReadFile("../../test/res/config.json")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -113,7 +134,7 @@ func TestTlsAnnotator_Serve(t *testing.T) {
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	tls := NewTlsAnnotator(cfg)
+	tls := NewTlsAnnotator(cfg, hash256.New(), ed25519.New())
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), contracts.AnnotationTLS, r.TLS)

--- a/pkg/config/sdk.go
+++ b/pkg/config/sdk.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2023 Dell Inc.
+ * Copyright 2024 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -61,13 +61,9 @@ func (s *SdkInfo) UnmarshalJSON(data []byte) (err error) {
 }
 
 func (s *SdkInfo) UnmarshalYAML(data *yaml.Node) (err error) {
-	type Alias struct {
-		Annotators []contracts.AnnotationType `yaml:"annotators"`
-		Hash       HashInfo                   `yaml:"hash"`
-		Signature  SignatureInfo              `yaml:"signature"`
-		Stream     StreamInfo                 `yaml:"stream"`
-	}
-	a := Alias{}
+	type Alias SdkInfo
+	a := &Alias{}
+
 	// Error with unmarshaling
 	if err = data.Decode(&a); err != nil {
 		return err
@@ -80,7 +76,12 @@ func (s *SdkInfo) UnmarshalYAML(data *yaml.Node) (err error) {
 				return fmt.Errorf("invalid AnnotationType received %s", x)
 			}
 		}
+
+		if !a.Layer.Validate() {
+			return fmt.Errorf("invalid Stack Layer received %s", string(a.Layer))
+		}
 	}
+
 	s.Annotators = a.Annotators
 	s.Hash = a.Hash
 	s.Signature = a.Signature

--- a/pkg/config/sdk_test.go
+++ b/pkg/config/sdk_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2024 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,17 +11,18 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package config
 
 import (
 	"encoding/json"
 	"github.com/project-alvarium/alvarium-sdk-go/test"
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
 func TestSDKInfo_UnmarshalJSON(t *testing.T) {
-	b, err := ioutil.ReadFile("../../test/res/config.json")
+	b, err := os.ReadFile("../../test/res/config.json")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -34,7 +35,7 @@ func TestSDKInfo_UnmarshalJSON(t *testing.T) {
 }
 
 func TestSDKInfo_AnnotationInvalid(t *testing.T) {
-	b, err := ioutil.ReadFile("../../test/res/config.json")
+	b, err := os.ReadFile("../../test/res/config.json")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/pkg/factories/factory_test.go
+++ b/pkg/factories/factory_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2023 Dell Inc.
+ * Copyright 2024 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,6 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package factories
 
 import (
@@ -18,6 +19,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/config"
@@ -66,8 +68,52 @@ func TestStreamProviderFactory(t *testing.T) {
 	}
 }
 
+func TestHashProviderFactory(t *testing.T) {
+	tests := []struct {
+		name         string
+		providerType contracts.HashType
+		expectError  bool
+	}{
+		{"valid md5 type", contracts.MD5Hash, false},
+		{"valid sha256 type", contracts.SHA256Hash, false},
+		{"valid none type", contracts.NoHash, false},
+		{"invalid hash type", "invalid", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewHashProvider(tt.providerType)
+			test.CheckError(err, tt.expectError, tt.name, t)
+		})
+	}
+}
+
+func TestSignatureProviderFactory(t *testing.T) {
+	tests := []struct {
+		name         string
+		providerType contracts.KeyAlgorithm
+		expectError  bool
+	}{
+		{"valid ed25519 type", contracts.KeyEd25519, false},
+		{"invalid hash type", "invalid", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewSignatureProvider(tt.providerType)
+			test.CheckError(err, tt.expectError, tt.name, t)
+		})
+	}
+}
+
 func TestAnnotatorFactory(t *testing.T) {
-	cfg := config.SdkInfo{}
+	b, err := os.ReadFile("../../test/res/config.json")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	var cfg config.SdkInfo
+	err = json.Unmarshal(b, &cfg)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
 
 	tests := []struct {
 		name        string

--- a/pkg/interfaces/hashing.go
+++ b/pkg/interfaces/hashing.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2024 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,11 +11,10 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
-package signprovider
 
-type Provider interface {
-	// Sign is the interface method for signing some content with a private key
-	Sign(key, content []byte) string
-	// Verify is the interface method using a public key to verify the signature derived from some piece of content
-	Verify(key, content, signed []byte) bool
+package interfaces
+
+type HashProvider interface {
+	// Derive converts data to an hash value.
+	Derive(data []byte) string
 }

--- a/pkg/interfaces/signature.go
+++ b/pkg/interfaces/signature.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2024 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,9 +11,16 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
-package hashprovider
 
-type Provider interface {
-	// Derive converts data to an hash value.
-	Derive(data []byte) string
+package interfaces
+
+import (
+	"github.com/project-alvarium/alvarium-sdk-go/pkg/config"
+)
+
+type SignatureProvider interface {
+	// Sign is the interface method for signing an annotation with a private key
+	Sign(key config.KeyInfo, content []byte) (string, error)
+	// Verify is the interface method using a public key to verify the signature derived from some piece of content
+	Verify(key config.KeyInfo, content, signed []byte) (bool, error)
 }

--- a/test/res/config.yaml
+++ b/test/res/config.yaml
@@ -1,6 +1,7 @@
 annotators:
   - tpm
   - pki
+layer: app
 hash:
   type: "sha256"
 signature:


### PR DESCRIPTION
- Adjust unit tests accordingly
- Tested locally using harness with custom "Secure Boot" annotator defined. This annotator consumes the new factory methods.

Fix #58