### PR TITLE
Fix `make test` errors

### DIFF
--- a/internal/annotators/base_test.go
+++ b/internal/annotators/base_test.go
@@ -15,6 +15,8 @@ package annotators
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/project-alvarium/alvarium-sdk-go/internal/hashprovider/md5"
 	"github.com/project-alvarium/alvarium-sdk-go/internal/hashprovider/none"
 	sha2562 "github.com/project-alvarium/alvarium-sdk-go/internal/hashprovider/sha256"
@@ -24,7 +26,6 @@ import (
 	"github.com/project-alvarium/alvarium-sdk-go/pkg/interfaces"
 	"github.com/project-alvarium/alvarium-sdk-go/test"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestDeriveHash(t *testing.T) {
@@ -68,7 +69,7 @@ func TestSignAnnotation(t *testing.T) {
 	//I'm using a JSON representation here b/c calling the Annotation constructor will populate different ID and Timestamp values each time.
 	//Thus the resulting signature will be different for each test run if I don't use something static.
 	var a contracts.Annotation
-	sample := "{\"id\":\"01F9MS7QVH8Z3KMW757RGFKCBG\",\"key\":\"dummyKey\",\"hash\":\"none\",\"host\":\"ubuntu\",\"type\":\"tpm\",\"timestamp\":\"2021-07-02T18:35:36.561920812-05:00\"}"
+	sample := "{\"id\":\"01F9MS7QVH8Z3KMW757RGFKCBG\",\"key\":\"dummyKey\",\"hash\":\"none\",\"host\":\"ubuntu\",\"tag\":\"e5ec0811a099446d00006f5d53f3b054f6733112\",\"layer\":\"app\",\"kind\":\"tpm\",\"isSatisfied\":false,\"timestamp\":\"2021-07-02T18:35:36.561920812-05:00\"}"
 	json.Unmarshal([]byte(sample), &a)
 
 	tests := []struct {
@@ -80,7 +81,7 @@ func TestSignAnnotation(t *testing.T) {
 		expectError bool
 	}{
 		{"valid ed25519 signature", private, a,
-			"dafcee0a1844b9c5c0db87252067afc06853afefa14b1711a7c24a6eabc6f6b76b91f8aae2ce54f74b54500dbaf303fbb23dc550e151cfe03cef68ae26a22306",
+			"969307e1116e607f0568d354dc156854b0f9977c95779038dc98c1dd177729644470a51e3d647e50a43cb338a803a1406a6feb3ff748586ee3c75847309de802",
 			ed25519.New(), false},
 	}
 	for _, tt := range tests {

--- a/pkg/config/sdk_test.go
+++ b/pkg/config/sdk_test.go
@@ -16,7 +16,6 @@ package config
 
 import (
 	"encoding/json"
-	"github.com/project-alvarium/alvarium-sdk-go/test"
 	"os"
 	"testing"
 )
@@ -34,22 +33,22 @@ func TestSDKInfo_UnmarshalJSON(t *testing.T) {
 	}
 }
 
-func TestSDKInfo_AnnotationInvalid(t *testing.T) {
-	b, err := os.ReadFile("../../test/res/config.json")
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
+// func TestSDKInfo_AnnotationInvalid(t *testing.T) {
+// 	b, err := os.ReadFile("../../test/res/config.json")
+// 	if err != nil {
+// 		t.Fatalf(err.Error())
+// 	}
 
-	var cfg SdkInfo
-	err = json.Unmarshal(b, &cfg)
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
+// 	var cfg SdkInfo
+// 	err = json.Unmarshal(b, &cfg)
+// 	if err != nil {
+// 		t.Fatalf(err.Error())
+// 	}
 
-	cfg.Annotators = append(cfg.Annotators, "invalid")
-	b, _ = json.Marshal(cfg)
+// 	cfg.Annotators = append(cfg.Annotators, "invalid")
+// 	b, _ = json.Marshal(cfg)
 
-	var x SdkInfo
-	err = json.Unmarshal(b, &x)
-	test.CheckError(err, true, "test sdk invalid annotation", t)
-}
+// 	var x SdkInfo
+// 	err = json.Unmarshal(b, &x)
+// 	test.CheckError(err, true, "test sdk invalid annotation", t)
+// }

--- a/pkg/config/sdk_test.go
+++ b/pkg/config/sdk_test.go
@@ -32,23 +32,3 @@ func TestSDKInfo_UnmarshalJSON(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 }
-
-// func TestSDKInfo_AnnotationInvalid(t *testing.T) {
-// 	b, err := os.ReadFile("../../test/res/config.json")
-// 	if err != nil {
-// 		t.Fatalf(err.Error())
-// 	}
-
-// 	var cfg SdkInfo
-// 	err = json.Unmarshal(b, &cfg)
-// 	if err != nil {
-// 		t.Fatalf(err.Error())
-// 	}
-
-// 	cfg.Annotators = append(cfg.Annotators, "invalid")
-// 	b, _ = json.Marshal(cfg)
-
-// 	var x SdkInfo
-// 	err = json.Unmarshal(b, &x)
-// 	test.CheckError(err, true, "test sdk invalid annotation", t)
-// }


### PR DESCRIPTION
Fix #65 
- Updated the static annotation used in TestSignAnnotation/valid_ed25519_signature to reflect the latest updates to the annotation schema (Like adding the tag and layer fields and fixing the kind field).
- Updated the test hash value corresponding to the static annotation in TestSignAnnotation/valid_ed25519_signature.
- Commented the invalid annotation type check, as it's not relevant after commenting out the annotation type checks.