### PR TITLE
Add OS and Host layers tag values

### DIFF
--- a/pkg/contracts/annotation.go
+++ b/pkg/contracts/annotation.go
@@ -52,6 +52,12 @@ func getTagValue(layer LayerType) string {
 	switch layer {
 	case Application:
 		return os.Getenv(TagEnvKey)
+	case Os:
+		hostname, _ := os.Hostname()
+		return hostname
+	case Host:
+		hostname, _ := os.Hostname()
+		return hostname
 	}
 	return ""
 }


### PR DESCRIPTION
Fix #67 
- Adds the tag value for both OS and Host layers. (hostname)